### PR TITLE
fixed update holder and rec of fragments

### DIFF
--- a/assets/test/text/test.txt
+++ b/assets/test/text/test.txt
@@ -1,0 +1,3 @@
+Hello!
+World 
+../../assets/test/media/image/drone.png


### PR DESCRIPTION
Before the holder of the receiving fragments vas an hashmap which cointained the vector of fragments received, protocols state that it should be a vec of u8 so I changed it.
TODO: update topology with all possible paths without cycles, and wieght added to each paths so that when drops or error occurs 
           every paths that contains the drone which caused it, the wieght of the entire path is incremented and we can choose one  
           with less weight and with less probability for errors, always update the topology