### PR TITLE
Added print of path and fixed topology, now taking correct node id increasing paths

### DIFF
--- a/src/utils/backup_server.rs
+++ b/src/utils/backup_server.rs
@@ -571,6 +571,7 @@ impl Server {
         self.server_topology.find_all_paths(self.id,server_id);
         self.server_topology.set_path_based_on_dst(server_id);
         let traces = self.server_topology.get_current_path();
+        info!("Sending fragment after nack.\nPath{:?}",traces.clone());
         
         if let Some((trace,_)) = traces {
             let packet = Packet::new_fragment(
@@ -611,7 +612,7 @@ impl Server {
         }
 
         let hops = self.get_hops(dst);
-        // println!("Hops in server: {:?}",hops);
+        info!("Hops in server: {:?}",hops);
 
         let bytes_res = deconstruct_message(response.clone());
         if let Ok(bytes) = bytes_res {
@@ -714,7 +715,7 @@ impl Server {
                             PacketType::MsgFragment(f) => {
                                 if f.fragment_index == nack.fragment_index {
                                     self.server_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     loop {
                                         self.server_topology.set_path_based_on_dst(*p.routing_header.hops.last().unwrap());
                                                                         
@@ -726,7 +727,7 @@ impl Server {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.server_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.server_topology.increment_weights_for_node(packet.routing_header.hops[0]);
                                         }
                                         std::thread::sleep(Duration::from_millis(10));
                                     }
@@ -736,7 +737,7 @@ impl Server {
                             PacketType::Ack(a) => {
                                 if a.fragment_index == nack.fragment_index {
                                     self.server_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     return self.send_ack(
                                         session_id,
                                         p.routing_header.hops.last().unwrap(),
@@ -765,7 +766,7 @@ impl Server {
                             PacketType::MsgFragment(f) => {
                                 if f.fragment_index == nack.fragment_index {
                                     self.server_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     loop {
                                         self.server_topology.set_path_based_on_dst(*p.routing_header.hops.last().unwrap());
                                                                         
@@ -777,7 +778,7 @@ impl Server {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.server_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.server_topology.increment_weights_for_node(packet.routing_header.hops[0]);
                                             std::thread::sleep(Duration::from_millis(10));
                                         }
                                     }
@@ -816,7 +817,7 @@ impl Server {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.server_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.server_topology.increment_weights_for_node(id);
                                         }
                                         std::thread::sleep(Duration::from_millis(10));
                                     }
@@ -862,7 +863,7 @@ impl Server {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.server_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.server_topology.increment_weights_for_node(id);
                                         }
                                         std::thread::sleep(Duration::from_millis(10));
                                     }

--- a/src/utils/client/chat_client.rs
+++ b/src/utils/client/chat_client.rs
@@ -478,7 +478,7 @@ impl ChatClient {
         self.client_topology.set_path_based_on_dst(server_id);
         let traces = self.client_topology.get_current_path();
         
-        info!("Path chosen to send to {:?}",traces.clone());
+        info!("Sending fragment after nack.\nPath{:?}",traces.clone());
         if let Some((trace,_)) = traces {
             let packet = Packet::new_fragment(
                 SourceRoutingHeader::with_first_hop(trace.clone()),
@@ -595,7 +595,7 @@ impl ChatClient {
                             PacketType::MsgFragment(f) => {
                                 if f.fragment_index == nack.fragment_index {
                                     self.client_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     loop {
                                         self.client_topology.set_path_based_on_dst(*p.routing_header.hops.last().unwrap());
                                                                         
@@ -607,7 +607,7 @@ impl ChatClient {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.client_topology.increment_weights_for_node(packet.routing_header.hops[0]);
                                         }
                                         std::thread::sleep(Duration::from_millis(100));
                                     }
@@ -617,7 +617,7 @@ impl ChatClient {
                             PacketType::Ack(a) => {
                                 if a.fragment_index == nack.fragment_index {
                                     self.client_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     return self.send_ack(
                                         session_id,
                                         p.routing_header.hops.last().unwrap(),
@@ -646,7 +646,7 @@ impl ChatClient {
                             PacketType::MsgFragment(f) => {
                                 if f.fragment_index == nack.fragment_index {
                                     self.client_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     loop {
                                         self.client_topology.set_path_based_on_dst(*p.routing_header.hops.last().unwrap());
                                                                         
@@ -658,7 +658,7 @@ impl ChatClient {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.client_topology.increment_weights_for_node(packet.routing_header.hops[0]);
                                             std::thread::sleep(Duration::from_millis(100));
                                         }
                                     }
@@ -697,7 +697,7 @@ impl ChatClient {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.client_topology.increment_weights_for_node(id);
                                         }
                                         std::thread::sleep(Duration::from_millis(100));
                                     }
@@ -743,7 +743,7 @@ impl ChatClient {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.client_topology.increment_weights_for_node(id);
                                         }
                                         std::thread::sleep(Duration::from_millis(100));
                                     }

--- a/src/utils/client/web_browser.rs
+++ b/src/utils/client/web_browser.rs
@@ -483,6 +483,7 @@ impl WebBrowser {
         self.client_topology.find_all_paths(self.id,server_id);
         self.client_topology.set_path_based_on_dst(server_id);
         let traces = self.client_topology.get_current_path();
+        info!("Sending fragment after nack.\nPath{:?}",traces.clone());
         if let Some((trace,_)) = traces {
             let packet = Packet::new_fragment(
                 SourceRoutingHeader::with_first_hop(trace.clone()),
@@ -598,7 +599,7 @@ impl WebBrowser {
                             PacketType::MsgFragment(f) => {
                                 if f.fragment_index == nack.fragment_index {
                                     self.client_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     loop {
                                         self.client_topology.set_path_based_on_dst(*p.routing_header.hops.last().unwrap());
                                                                         
@@ -610,9 +611,9 @@ impl WebBrowser {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.client_topology.increment_weights_for_node(packet.routing_header.hops[0]);
                                         }
-                                        std::thread::sleep(Duration::from_millis(10));
+                                        std::thread::sleep(Duration::from_millis(100));
                                     }
                                     return Ok(());
                                 }
@@ -620,7 +621,7 @@ impl WebBrowser {
                             PacketType::Ack(a) => {
                                 if a.fragment_index == nack.fragment_index {
                                     self.client_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     return self.send_ack(
                                         session_id,
                                         p.routing_header.hops.last().unwrap(),
@@ -649,7 +650,7 @@ impl WebBrowser {
                             PacketType::MsgFragment(f) => {
                                 if f.fragment_index == nack.fragment_index {
                                     self.client_topology
-                                        .increment_weights_for_node(p.routing_header.hops[0]);
+                                        .increment_weights_for_node(packet.routing_header.hops[0]);
                                     loop {
                                         self.client_topology.set_path_based_on_dst(*p.routing_header.hops.last().unwrap());
                                                                         
@@ -661,8 +662,8 @@ impl WebBrowser {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
-                                            std::thread::sleep(Duration::from_millis(10));
+                                            self.client_topology.increment_weights_for_node(packet.routing_header.hops[0]);
+                                            std::thread::sleep(Duration::from_millis(100));
                                         }
                                     }
                                     return Ok(());
@@ -700,9 +701,9 @@ impl WebBrowser {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.client_topology.increment_weights_for_node(id);
                                         }
-                                        std::thread::sleep(Duration::from_millis(10));
+                                        std::thread::sleep(Duration::from_millis(100));
                                     }
                                     return Ok(());
                                 }
@@ -746,9 +747,9 @@ impl WebBrowser {
                                             break;
                                         } else {
                                             // Optionally: increase weights for the failed path to avoid it
-                                            self.client_topology.increment_weights_for_node(p.routing_header.hops[0]);
+                                            self.client_topology.increment_weights_for_node(id);
                                         }
-                                        std::thread::sleep(Duration::from_millis(10));
+                                        std::thread::sleep(Duration::from_millis(100));
                                     }
                                     return Ok(());
                                 }

--- a/src/utils/topology.rs
+++ b/src/utils/topology.rs
@@ -163,7 +163,9 @@ impl Topology {
                 .min_by_key(|(_, weight)| weight)
                 .cloned();
 
+            // info!("\nCurrent Path {:?}\nBest_path: {:?}\n",self.current_path.clone(),best_path.clone());
             self.current_path = best_path.clone();
+            // info!("\nCurrent Path {:?}\nBest_path: {:?}\n",self.current_path.clone(),best_path.clone());
 
         } else {
             println!("⚠️ No paths available to select for dst: {:?}", dst);
@@ -171,12 +173,11 @@ impl Topology {
     }
 
     pub fn get_current_path(&self) -> Option<(Vec<NodeId>,u64)> {
-        // info!("Current Path {:?}\n{:?}",self.current_path.clone(),self.paths);
         self.current_path.clone()
     }
 
     pub fn increment_weights_for_node(&mut self, node_id: NodeId) {
-        
+        info!("Nack produced in {}",node_id);
         if let Some((current_path, weight)) = &mut self.current_path {
             if current_path.contains(&node_id) {
                 *weight += 1;
@@ -184,8 +185,9 @@ impl Topology {
         }
 
         if let Some(paths) = &mut self.paths {
-            for (_, weight) in paths.iter_mut() {
-                if *weight < 100000 { // upper bound for a path to not increase anymore
+            for (p, weight) in paths.iter_mut() {
+                if *weight < 100000 && p.contains(&node_id){ // upper bound for a path to not increase anymore
+                    // info!("Path's weight to increment: {:?}",p.clone());
                     *weight += 1;
                 }
             }


### PR DESCRIPTION

```rust
fn recv_nack_n_handle(&mut self, packet: &Packet, ...) {
    // ... other logic

    for (p,_) in holder_sent.clone() {  // holder of all packets sent
        // Previously incorrect logic:
        self.topology.increment_weights_for_node(p.routing_header.hops[0]);

        // Correct logic: use the packet that triggered the NACK
        self.topology.increment_weights_for_node(packet.routing_header.hops[0]);
    }

    // ... other logic
}
```
